### PR TITLE
Switched over to new instance_eval config methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Or install it yourself as:
 
     $ gem install gitnesse
 
-For Rails 3, create an initializer file config/initializer/gitnesse.rb like this:
+Create a `gitnesse.rb` file somewhere in your project, and add something like
+the following to it:
 
-    Gitnesse.config do |config|
-      config.repository_url = "git@github.com:hybridgroup/gitnesse-demo.wiki"
+    Gitnesse.config do
+      repository_url "git@github.com:hybridgroup/gitnesse-demo.wiki"
     end
 
 ## Usage

--- a/lib/gitnesse.rb
+++ b/lib/gitnesse.rb
@@ -279,4 +279,9 @@ module Gitnesse
       "branch" => Gitnesse.branch,
       "target_directory" => Gitnesse.target_directory }
   end
+
+  def method_missing(sym, *args, &block)
+    raise "Invalid variable name for Gitnesse configuration.
+           Allowed variables are repository_url, branch, and target_directory."
+  end
 end

--- a/lib/gitnesse.rb
+++ b/lib/gitnesse.rb
@@ -7,11 +7,7 @@ require 'gitnesse/railtie' if defined?(Rails::Railtie)
 # core module
 module Gitnesse
 
-  # Public: Return String with url of the git wiki repo containing features.
-  #
-  def self.repository_url
-    @@repository_url
-  end
+  extend self
 
   # Public: Set url of the git-based wiki repo containing features.
   #
@@ -19,18 +15,16 @@ module Gitnesse
   #
   # Example:
   #
-  #   Gitnesse.config do |config|
-  #     config.repository_url = "git@github.com:luishurtado/gitnesse-wiki.wiki"
+  #   Gitnesse.config do
+  #     repository_url  "git@github.com:luishurtado/gitnesse-wiki.wiki"
   #   end
   #
-  def self.repository_url=(repository_url)
-    @@repository_url = repository_url
-  end
-
-  # Public: Return String with branch of the git-based wiki repo containing features.
-  #
-  def self.branch
-    @@branch ||= "master"
+  def self.repository_url(repository_url = false)
+    if repository_url == false
+      @@repository_url
+    else
+      @@repository_url = repository_url
+    end
   end
 
   # Public: Set branch of the git-based wiki repo containing features.
@@ -39,18 +33,16 @@ module Gitnesse
   #
   # Example:
   #
-  #   Gitnesse.config do |config|
-  #     config.branch = "master"
+  #   Gitnesse.config do
+  #     branch "master"
   #   end
   #
-  def self.branch=(branch)
-    @@branch = branch
-  end
-
-  # Public: Return String with which directory being used to sync with git-wiki stored feature stories.
-  #
-  def self.target_directory
-    @@target_directory ||= File.join(Dir.pwd, 'features')
+  def self.branch(branch = false)
+    if branch == false
+      @@branch ||= "master"
+    else
+      @@branch = branch
+    end
   end
 
   # Public: Set local directory used to sync with git-wiki stored feature stories.
@@ -59,16 +51,20 @@ module Gitnesse
   #
   # Example:
   #
-  #   Gitnesse.config do |config|
-  #     config.target_directory = "features"
+  #   Gitnesse.config do
+  #     target_directory "features"
   #   end
   #
-  def self.target_directory=(target_directory)
-    @@target_directory = target_directory
+  def self.target_directory(target_directory = false)
+    if target_directory == false
+      @@target_directory ||= File.join(Dir.pwd, 'features')
+    else
+      @@target_directory = target_directory
+    end
   end
 
-  def self.config
-    yield self
+  def self.config(&block)
+    instance_eval &block
   end
 
   # -- all methods after this are module functions --

--- a/test/lib/gitnesse/check_dependencies_test.rb
+++ b/test/lib/gitnesse/check_dependencies_test.rb
@@ -5,12 +5,12 @@ describe Gitnesse do
     let(:method) { lambda { Gitnesse.ensure_repository } }
 
     describe "when repository was defined" do
-      before { Gitnesse.stubs(:repository_url).returns("git://github.com/hybridgroup/gitnesse-demo.wiki") }
+      before { Gitnesse.repository_url("git://github.com/hybridgroup/gitnesse-demo.wiki") }
       it { method.call.must_be_nil }
     end
 
     describe "when repository was not defined" do
-      before { Gitnesse.stubs(:repository_url).returns(nil) }
+      before { Gitnesse.repository_url(nil) }
       it { method.must_raise(RuntimeError) }
     end
   end

--- a/test/lib/gitnesse/config_to_hash_test.rb
+++ b/test/lib/gitnesse/config_to_hash_test.rb
@@ -4,10 +4,10 @@ describe Gitnesse do
   describe ".config_to_hash" do
     let(:method) { lambda { Gitnesse.config_to_hash } }
     before do
-      Gitnesse.config do |config|
-        config.repository_url   = "git://github.com/hybridgroup/gitnesse-demo.wiki.git"
-        config.branch           = "wiki"
-        config.target_directory = "feature_files"
+      Gitnesse.config do
+        repository_url   "git://github.com/hybridgroup/gitnesse-demo.wiki.git"
+        branch           "wiki"
+        target_directory "feature_files"
       end
     end
 

--- a/test/lib/gitnesse/custom_branch_test.rb
+++ b/test/lib/gitnesse/custom_branch_test.rb
@@ -2,20 +2,20 @@ require_relative '../../test_helper'
 
 describe Gitnesse do
   describe "#branch" do
-    describe "when default to 'master'" do
-      before { Gitnesse.branch = nil }
+    describe "defaults to 'master'" do
+      before { Gitnesse.branch nil }
       it { Gitnesse.branch.must_equal "master" }
     end
 
     describe "when changed" do
-      before { Gitnesse.branch = "wiki" }
+      before { Gitnesse.branch "wiki" }
       it { Gitnesse.branch.must_equal "wiki" }
     end
 
     describe "when changed through #config" do
       before do
-        Gitnesse.config do |config|
-          config.branch = "wiki"
+        Gitnesse.config do
+          branch "wiki"
         end
       end
 


### PR DESCRIPTION
Config blocks now look like this:

``` ruby
Gitnesse.config do
  repository_url "path_to_git_repo"
  branch "wiki"
end
```

Will update gh-pages branch to reflect this change after it's merged. I'll make the change to the Readme in just a sec.

I'm not sure if this is necessary, but would an error message on method_missing be helpful?
