### PR TITLE
`gitnesse run` Improvements

### DIFF
--- a/lib/gitnesse/cli.rb
+++ b/lib/gitnesse/cli.rb
@@ -15,7 +15,8 @@ module Gitnesse
     end
 
     def parse(args = ARGV)
-      parser.parse! args
+      # gitnesse run will pass all arguments onto cucumber
+      parser.parse! args unless ARGV.first == "run"
 
       arg = args.shift.to_s
 

--- a/lib/gitnesse/cli/task/run.rb
+++ b/lib/gitnesse/cli/task/run.rb
@@ -11,12 +11,16 @@ Pulls changed features from remote git-based wiki, runs Cucumber, and pushes
 annotated results to the remote git-based wiki if the "annotate_results" setting
 is enabled.
 
+Unlike other commands, all arguments passed to gitnesse run will be passed
+through to Cucumber if you only want to run specific cukes.
+
 Examples:
   gitnesse run  # will pull changes, run cucumber, and annotate results
+  gitnesse run ./features/addition.feature
     EOS
   end
 
-  def perform
+  def perform(*args)
     load_and_check_config
     clone_wiki
     extract_features_from_wiki
@@ -27,7 +31,7 @@ Examples:
     remove_existing_results_from_wiki
 
     create_hooks
-    run_features
+    run_features(args)
     remove_hooks
 
     push_annotated_results_to_wiki
@@ -64,15 +68,19 @@ Examples:
 
   # Public: Runs Cucumber features
   #
+  # args - optional array of arguments to be passed to Cucumber
+  #
   # Returns nothing
-  def run_features
-    puts "  Running cucumber."
-    puts '  -------------------', ''
+  def run_features(args = [])
+    puts "  Running cucumber.", '  -------------------', ''
+    args = (args.empty? ? @config.features_dir : args.join(' '))
+
     if defined?(Bundler)
-      Bundler.with_clean_env { system "bundle exec cucumber #{@config.features_dir}" }
+      Bundler.with_clean_env { system "bundle exec cucumber #{args}" }
     else
-      system "bundle exec cucumber #{@config.features_dir}"
+      system "bundle exec cucumber #{args}"
     end
+
     puts '  -------------------', ''
   end
 

--- a/lib/gitnesse/cli/task/run.rb
+++ b/lib/gitnesse/cli/task/run.rb
@@ -69,9 +69,9 @@ Examples:
     puts "  Running cucumber."
     puts '  -------------------', ''
     if defined?(Bundler)
-      Bundler.with_clean_env { system "cucumber #{@config.features_dir}" }
+      Bundler.with_clean_env { system "bundle exec cucumber #{@config.features_dir}" }
     else
-      system "cucumber #{@config.features_dir}"
+      system "bundle exec cucumber #{@config.features_dir}"
     end
     puts '  -------------------', ''
   end

--- a/lib/gitnesse/hooks.rb
+++ b/lib/gitnesse/hooks.rb
@@ -33,13 +33,12 @@ module Gitnesse
 
       if scenario.respond_to?(:scenario_outline)
         file = scenario.scenario_outline.file.gsub(/^#{@config.features_dir}\//, '')
-        name = scenario.name.split("|")
-        name.shift
-        name = name.map! { |s| s.strip.lstrip }
-        name = "#{scenario.scenario_outline.name} - (#{name.join(', ')})"
+        name = "#{scenario.scenario_outline.name}"
+        subtitle = scenario.name.gsub(/(^\|\s+|\s+\|$)/, '').gsub(/\s+\|/, ',')
       else
         file = scenario.file.gsub(/^#{@config.features_dir}\//, '')
         name = scenario.name
+        subtitle = nil
       end
 
       page = file.gsub("/", " > ")
@@ -50,7 +49,7 @@ module Gitnesse
 
       return unless page
 
-      page.append_result name, status
+      page.append_result name, status, subtitle
       @wiki.repo.add(page.wiki_path)
     end
   end

--- a/lib/gitnesse/hooks.rb
+++ b/lib/gitnesse/hooks.rb
@@ -31,10 +31,18 @@ module Gitnesse
       Gitnesse::ConfigLoader.find_and_load
       dir = Gitnesse::DirManager.project_dir
 
-      file = scenario.file.gsub(/^#{@config.features_dir}\//, '')
+      if scenario.respond_to?(:scenario_outline)
+        file = scenario.scenario_outline.file.gsub(/^#{@config.features_dir}\//, '')
+        name = scenario.name.split("|")
+        name.shift
+        name = name.map! { |s| s.strip.lstrip }
+        name = "#{scenario.scenario_outline.name} - (#{name.join(', ')})"
+      else
+        file = scenario.file.gsub(/^#{@config.features_dir}\//, '')
+        name = scenario.name
+      end
 
       page = file.gsub("/", " > ")
-      name = scenario.name
       status = scenario.status
 
       @wiki = Gitnesse::Wiki.new(@config.repository_url, dir, clone: false)

--- a/lib/gitnesse/wiki/page.rb
+++ b/lib/gitnesse/wiki/page.rb
@@ -50,20 +50,17 @@ module Gitnesse
       # scenario - feature scenario that was run
       # status - return status of the scenario, e.g. :passed, :undefined,
       # :failing
+      # subtitle - subtitle of scenario (used for scenario outlines)
       #
       # Returns nothing
-      def append_result(scenario, status)
+      def append_result(scenario, status, subtitle = nil)
         image = "![](//s3.amazonaws.com/gitnesse/github/#{status.to_s}.png)"
         time = Time.now.strftime("%b %d, %Y, %-l:%M %p")
         identifier = Gitnesse::Config.instance.identifier
 
-        string = <<-EOS.chomp
-
-- #{image} **#{scenario}**
-- #{identifier} - #{time}
-
----
-        EOS
+        string = "\n- #{image} **#{scenario}**".chomp
+        string << "\n- **(#{subtitle})**" if subtitle
+        string << "\n- #{identifier} - #{time}\n\n---"
 
         write(read + string)
       end

--- a/lib/gitnesse/wiki/page.rb
+++ b/lib/gitnesse/wiki/page.rb
@@ -41,7 +41,7 @@ module Gitnesse
       #
       # Returns nothing
       def remove_results
-        write(read.gsub(/(\s+\!\[\].*)/, ''))
+        write(read.gsub(/\s+- !\[\].*---/m, ''))
       end
 
       # Public: Appends the result of a Cucumber scenario to the feature's wiki
@@ -53,13 +53,17 @@ module Gitnesse
       #
       # Returns nothing
       def append_result(scenario, status)
-        status = status.to_s
-        image = "![](https://s3.amazonaws.com/gitnesse/github/#{status}.png)"
-        string = "\n\n#{image} \`"
-        string << "Last Result For Scenario '#{scenario}': "
-        string << status.upcase
-        string << " (#{Time.now.strftime("%b %d, %Y, %-l:%M %p")} - "
-        string << "#{Gitnesse::Config.instance.identifier})\`"
+        image = "![](//s3.amazonaws.com/gitnesse/github/#{status.to_s}.png)"
+        time = Time.now.strftime("%b %d, %Y, %-l:%M %p")
+        identifier = Gitnesse::Config.instance.identifier
+
+        string = <<-EOS.chomp
+
+- #{image} **#{scenario}**
+- #{identifier} - #{time}
+
+---
+        EOS
 
         write(read + string)
       end

--- a/spec/support_helper.rb
+++ b/spec/support_helper.rb
@@ -57,8 +57,10 @@ class Support
 ```gherkin
 #{division_feature}
 ```
+- ![](//s3.amazonaws.com/gitnesse/github/passed.png) **Divide two numbers**
+-  - Sep 06, 2013, 10:10 AM
 
-![](https://s3.amazonaws.com/gitnesse/github/passed.png) `Last Result For Scenario 'Divide two numbers': PASSED (Sep 06, 2013, 10:10 AM - )`
+---
       EOS
     end
 


### PR DESCRIPTION
`gitnesse run` now allows arguments to be passed through to Cucumber, handles `Scenario Outline` Cucumber features, and has a fancy new scenario results look:

``` gherkin
Feature: Food

  Scenario Outline: eating
    Given there are <start> cucumbers
    When I eat <eat> cucumbers
    Then I should have <left> cucumbers

    Examples:
      | start | eat | left |
      |  12   |  5  |  7   |
      |  20   |  5  |  15  |
```
- ![](//s3.amazonaws.com/gitnesse/github/passed.png) **eating**
- **(12, 5, 7)**
- Andrew Stewart's MacBook - Oct 09, 2013, 7:45 PM

---
- ![](//s3.amazonaws.com/gitnesse/github/passed.png) **eating**
- **(20, 5, 15)**
- Andrew Stewart's MacBook - Oct 09, 2013, 7:45 PM

---

Fixes https://github.com/hybridgroup/gitnesse/issues/21.
