### PR TITLE
Adds a config setting for result image URL scheme

### DIFF
--- a/lib/gitnesse/config.rb
+++ b/lib/gitnesse/config.rb
@@ -5,7 +5,8 @@ module Gitnesse
     include Singleton
 
     ConfigStruct = Struct.new :repository_url, :features_dir, :branch,
-                              :annotate_results, :identifier
+                              :annotate_results, :identifier,
+                              :image_scheme
 
     # Config Options:
     #
@@ -18,6 +19,8 @@ module Gitnesse
     # identifier       - if annotate_results is checked, an identifier to use
     #                    to indicate who ran the cukes.
     #                    e.g. "Uncle Bob's MacBook Air"
+    # image_scheme     - if annotate_results is checked, a scheme to use to
+    #                    generate result image URLs
 
     @@config = ConfigStruct.new
 

--- a/lib/gitnesse/dir_manager.rb
+++ b/lib/gitnesse/dir_manager.rb
@@ -27,10 +27,10 @@ module Gitnesse
         File.directory? project_dir
       end
 
-      private
-      # Private: Constructs project dir path in ~/.gitnesse folder
+      # Public: Constructs project dir path in ~/.gitnesse folder
       #
       # Returns a string path
+      # TODO: Refactor uses of this so it can be made private.
       def project_dir
         @project_dir ||= begin
           "#{Dir.home(Etc.getlogin)}/.gitnesse/#{File.basename(Dir.pwd)}"

--- a/lib/gitnesse/wiki/page.rb
+++ b/lib/gitnesse/wiki/page.rb
@@ -58,7 +58,11 @@ module Gitnesse
       #
       # Returns nothing
       def append_result(scenario, status, subtitle = nil)
-        image = "![](//s3.amazonaws.com/gitnesse/github/#{status.to_s}.png)"
+        scheme = Gitnesse::Config.instance.image_scheme
+        scheme += ':' unless scheme.nil?
+        image = "![](#{scheme.to_s}//s3.amazonaws.com/gitnesse/github/#{status.to_s}.png)"
+        #image = "![](//s3.amazonaws.com/gitnesse/github/#{status.to_s}.png)"
+
         time = Time.now.strftime("%b %d, %Y, %-l:%M %p")
         identifier = Gitnesse::Config.instance.identifier
 

--- a/lib/gitnesse/wiki/page.rb
+++ b/lib/gitnesse/wiki/page.rb
@@ -58,9 +58,7 @@ module Gitnesse
       #
       # Returns nothing
       def append_result(scenario, status, subtitle = nil)
-        scheme = Gitnesse::Config.instance.image_scheme
-        scheme += ':' unless scheme.nil?
-        image = "![](#{scheme.to_s}//s3.amazonaws.com/gitnesse/github/#{status.to_s}.png)"
+        image = "![](#{image_scheme}//s3.amazonaws.com/gitnesse/github/#{status.to_s}.png)"
         #image = "![](//s3.amazonaws.com/gitnesse/github/#{status.to_s}.png)"
 
         time = Time.now.strftime("%b %d, %Y, %-l:%M %p")
@@ -106,6 +104,22 @@ module Gitnesse
       #   get_filename #=> "thing.feature"
       def get_filename
         File.basename(@wiki_path, '.md').scan(/(\w+\.feature)$/).flatten.first
+      end
+
+      # Protected: Get a usable image scheme from the configuration
+      #
+      # Returns a string containing the configured image scheme (or empty)
+      #
+      # Examples:
+      #
+      #   image_scheme => ''
+      #   Config.instance.image_scheme = 'http'
+      #   image_scheme => 'http:'
+      #   Config.instance.image_scheme = 'https'
+      #   image_scheme => 'https:
+      def image_scheme
+        scheme = Config.instance.image_scheme
+        scheme.nil? ? '' : "#{scheme}:"
       end
     end
   end

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,9 @@ available configuration options are:
   results to wiki pages when `gitnesse run` is called. Defaults to `false`.
 - **identifier** - If annotate_results is true, an identifier to use to indicate
   who ran the results. e.g. `Uncle Bob's Laptop`.
+- **image_scheme** - If set, the scheme in question will be prepended to the
+  result set image URLs. This is useful for non-GitHub wikis (specifically,
+  GitLab)
 
 ## Tasks
 

--- a/spec/lib/cli/task/info_spec.rb
+++ b/spec/lib/cli/task/info_spec.rb
@@ -11,6 +11,7 @@ Current Gitnesse Configuration:
             branch - master
   annotate_results - [not set]
         identifier - [not set]
+      image_scheme - [not set]
       EOS
     end
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -9,7 +9,8 @@ module Gitnesse
         branch: 'master',
         identifier: nil,
         features_dir: 'features',
-        repository_url: nil
+        repository_url: nil,
+        image_scheme: nil
       }
     end
 

--- a/spec/lib/wiki/page_spec.rb
+++ b/spec/lib/wiki/page_spec.rb
@@ -64,45 +64,31 @@ module Gitnesse
         expect(page.read).to eq Support.wiki_feature_with_annotations
       end
 
-      context "when image_scheme is not set" do
-        it "does not set a URL scheme for result images" do
-          page.append_result('Divide two numbers', :passed)
-          page.read.split("\n").tap do |lines|
-            lines.each do |line|
-              if line =~ /!\[\]\((.*)\)/
-                expect(URI.parse($1).scheme).to be_nil
-              end
-            end
-          end
-        end
+      it "uses no scheme for result images when image_scheme is not set" do
+        page.append_result('Divide two numbers', :passed)
+        imglist = page.read.split("\n").
+          map {|line| line =~ /!\[\]\((.*)\)/ && $1}.
+          select {|line| !line.nil?}
+        imglist.each {|img| expect(URI.parse(img).scheme).to be_nil}
       end
 
-      context "when image_scheme is http" do
-        it "uses http for result images" do
-          Config.instance.image_scheme = 'http'
-          page.append_result('Divide two numbers', :passed)
-          page.read.split("\n").tap do |lines|
-            lines.each do |line|
-              if line =~ /!\[\]\((.*)\)/
-                expect(URI.parse($1).scheme).to eql('http')
-              end
-            end
-          end
-        end
+    
+      it "uses http for result images when image_scheme is set" do
+        Config.instance.image_scheme = 'http'
+        page.append_result('Divide two numbers', :passed)
+        imglist = page.read.split("\n").
+          map {|line| line =~ /!\[\]\((.*)\)/ && $1}.
+          select {|line| !line.nil?}
+        imglist.each {|img| expect(URI.parse(img).scheme).to eql('http')}
       end
 
-      context "when image_scheme is https" do
-        it "uses https for result images" do
-          Config.instance.image_scheme = 'https'
-          page.append_result('Divide two numbers', :passed)
-          page.read.split("\n").tap do |lines|
-            lines.each do |line|
-              if line =~ /!\[\]\((.*)\)/
-                expect(URI.parse($1).scheme).to eql('https')
-              end
-            end
-          end
-        end
+      it "uses https for result images" do
+        Config.instance.image_scheme = 'https'
+        page.append_result('Divide two numbers', :passed)
+        imglist = page.read.split("\n").
+          map {|line| line =~ /!\[\]\((.*)\)/ && $1}.
+          select {|line| !line.nil?}
+        imglist.each {|img| expect(URI.parse(img).scheme).to eql('https')}
       end
     end
   end

--- a/spec/lib/wiki/page_spec.rb
+++ b/spec/lib/wiki/page_spec.rb
@@ -63,6 +63,47 @@ module Gitnesse
         page.append_result('Divide two numbers', :passed)
         expect(page.read).to eq Support.wiki_feature_with_annotations
       end
+
+      context "when image_scheme is not set" do
+        it "does not set a URL scheme for result images" do
+          page.append_result('Divide two numbers', :passed)
+          page.read.split("\n").tap do |lines|
+            lines.each do |line|
+              if line =~ /!\[\]\((.*)\)/
+                expect(URI.parse($1).scheme).to be_nil
+              end
+            end
+          end
+        end
+      end
+
+      context "when image_scheme is http" do
+        it "uses http for result images" do
+          Config.instance.image_scheme = 'http'
+          page.append_result('Divide two numbers', :passed)
+          page.read.split("\n").tap do |lines|
+            lines.each do |line|
+              if line =~ /!\[\]\((.*)\)/
+                expect(URI.parse($1).scheme).to eql('http')
+              end
+            end
+          end
+        end
+      end
+
+      context "when image_scheme is https" do
+        it "uses https for result images" do
+          Config.instance.image_scheme = 'https'
+          page.append_result('Divide two numbers', :passed)
+          page.read.split("\n").tap do |lines|
+            lines.each do |line|
+              if line =~ /!\[\]\((.*)\)/
+                expect(URI.parse($1).scheme).to eql('https')
+              end
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
So, it turns out that some non-GitHub wikis (in my specific case, the gollum included in recent GitLab) don't handle the schemeless image URLs for annotated results very well. Or, really, at all.

This adds an image_scheme config option so those of us using GitHub alternatives can still see our results all pretty like.

Note: This also includes the "project_dir can't be private" commit requested for merge in hybridgroup/gitnesse#28
