### PR TITLE
Update the link format. Solves #30

### DIFF
--- a/lib/gitnesse/feature.rb
+++ b/lib/gitnesse/feature.rb
@@ -57,7 +57,7 @@ module Gitnesse
     #
     # Returns a string containing the relative link as markdown
     def relative_link
-      "[[#{wiki_filename.gsub('.md', '')}]]"
+      "[#{wiki_filename.gsub('.md', '')}](#{wiki_filename.gsub('.md', '')})"
     end
   end
 end


### PR DESCRIPTION
According to http://daringfireball.net/projects/markdown/syntax#link [Text](Link) is a valid syntax for links. In BitBucket Wiki this is the format for relative links.
