### PR TITLE
Fix file resolution in hooks

### DIFF
--- a/gitnesse.gemspec
+++ b/gitnesse.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bundler"
-  spec.add_dependency "git", "1.2.6"
+  spec.add_dependency "git", "1.2.9.1"
   spec.add_development_dependency "rake", "10.3.2"
   spec.add_development_dependency "rspec",   "2.14.1"
   spec.add_development_dependency "cucumber", "1.3.15"

--- a/lib/gitnesse/hooks.rb
+++ b/lib/gitnesse/hooks.rb
@@ -34,11 +34,11 @@ module Gitnesse
       if scenario.respond_to?(:scenario_outline)
         outline = scenario.scenario_outline
 
-        file = outline.file.gsub(/^#{@config.features_dir}\//, '')
+        file = filename_for(outline).gsub(/^#{@config.features_dir}\//, '')
         name = "#{outline.name}"
         subtitle = scenario.name.gsub(/(^\|\s+|\s+\|$)/, '').gsub(/\s+\|/, ',')
       else
-        file = scenario.file.gsub(/^#{@config.features_dir}\//, '')
+        file = filename_for(scenario).gsub(/^#{@config.features_dir}\//, '')
         name = scenario.name
         subtitle = nil
       end
@@ -53,6 +53,10 @@ module Gitnesse
 
       page.append_result name, status, subtitle
       @wiki.repo.add(page.wiki_path)
+    end
+
+    def filename_for(scenario)
+      scenario.respond_to?(:file) ? scenario.file : scenario.location.file
     end
   end
 end

--- a/lib/gitnesse/hooks.rb
+++ b/lib/gitnesse/hooks.rb
@@ -55,7 +55,7 @@ module Gitnesse
       @wiki.repo.add(page.wiki_path)
     end
 
-    def filename_for(scenario)
+    def self.filename_for(scenario)
       scenario.respond_to?(:file) ? scenario.file : scenario.location.file
     end
   end


### PR DESCRIPTION
Apparently, the `#file` method for scenarios and outlines in newer Cucumber versions has been moved a layer deeper.

This adds a filename resolver that works for both older and current Cucumber.
